### PR TITLE
Bugfix: Must specify a region

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,4 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/ulfsri/neris-api-client"
-Issues = "https://github.com/ulfsri/neris-api-client/issues"
+Issues = "https://neris.atlassian.net/servicedesk/customer/portal/3/group/3/create/10027"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neris_api_client"
-version = "0.1.4post0"
+version = "0.1.5"
 authors = [
   { name="Ben Coleman", email="ben.coleman@ul.org" },
 ]

--- a/src/neris_api_client/client.py
+++ b/src/neris_api_client/client.py
@@ -1,3 +1,4 @@
+import os
 import jwt
 import json
 from enum import Enum
@@ -38,6 +39,8 @@ BASE_URLS = {
 COGNITO_CLIENT_CONFIG_URL = (
     "https://neris-{env}-public.s3.us-east-2.amazonaws.com/cognito_config.json"
 )
+
+os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
 
 
 class _NerisApiClient:

--- a/src/neris_api_client/client.py
+++ b/src/neris_api_client/client.py
@@ -203,7 +203,12 @@ class _NerisApiClient:
                 e.args = e.args + (e.response.text,)
                 raise e
 
-        return res.json()
+        try:
+            response = res.json()
+        except requests.exceptions.JSONDecodeError:
+            response = res.text
+
+        return response
 
 
 class NerisApiClient(_NerisApiClient):


### PR DESCRIPTION
If `AWS_DEFAULT_REGION` is not set in the environment and `~/.aws/config` does not exist then creating a `boto3` client for `cognito-idp` will fail. This sets the `AWS_DEFAULT_REGION` in the process's environment to avoid that.

Update the issues URL to the helpdesk as we're not using Github issues.

When an empty response is returned, do not error. This is a valid state.