### PR TITLE
fix typo: acredited -> accredited, capitalize acronyms

### DIFF
--- a/src/neris_api_client/models.py
+++ b/src/neris_api_client/models.py
@@ -175,15 +175,15 @@ class Actions(Enum):
 
 
 class AssessmentPayload(BaseModel):
-    iso_rating: Optional[int] = Field(None, title="Iso Rating")
-    cpse_acredited: Optional[bool] = Field(None, title="Cpse Acredited")
-    caas_acredited: Optional[bool] = Field(None, title="Caas Acredited")
+    iso_rating: Optional[int] = Field(None, title="ISO Rating")
+    cpse_accredited: Optional[bool] = Field(None, title="CPSE Accredited")
+    caas_accredited: Optional[bool] = Field(None, title="CAAS Accredited")
 
 
 class AssessmentResponse(BaseModel):
-    iso_rating: Optional[int] = Field(None, title="Iso Rating")
-    cpse_acredited: Optional[bool] = Field(None, title="Cpse Acredited")
-    caas_acredited: Optional[bool] = Field(None, title="Caas Acredited")
+    iso_rating: Optional[int] = Field(None, title="ISO Rating")
+    cpse_accredited: Optional[bool] = Field(None, title="CPSE Accredited")
+    caas_accredited: Optional[bool] = Field(None, title="CAAS Accredited")
 
 
 class BodyUpsertLogoEntityNerisIdEntityLogoPut(BaseModel):


### PR DESCRIPTION
I'm not sure if this is the correct place to bring this to UL-FSRI's attention but I noticed a typo. Accredited was spelled 'acredited' in `models.py`. I corrected the issue and am sending a pull request but it seems likely that the upstream source for these codegen-based models would need updating as well if this is a good change.