### PR TITLE
Use `python-dotenv` and not deprecated `dotenv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neris_api_client"
-version = "1.2.0rc1"
+version = "1.2.0rc2"
 authors = [
   { name="Ben Coleman", email="ben.coleman@ul.org" },
   { name="Tommy Messbauer", email="thomas.messbauer@ul.org" },
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "requests",
     "pydantic[email]>=2",
-    "dotenv",
+    "python-dotenv",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dotenv
+python-dotenv
 pydantic[email]
 requests


### PR DESCRIPTION
`pip install` failed with `dotenv`