### PR TITLE
Fix authentication issue when password grant type is used.

### DIFF
--- a/src/neris_api_client/client.py
+++ b/src/neris_api_client/client.py
@@ -65,7 +65,7 @@ class _NerisApiClient:
                     res = self._session.post(
                         token_url,
                         headers={},
-                        json={
+                        data={
                             "grant_type": GrantType.PASSWORD,
                             "username": self.config.username,
                             "password": self.config.password,


### PR DESCRIPTION
### Problem:
Password grant type authentication is failed because json request content type is used instead application/x-www-form-urlencoded for Issue Token route.

### Solution:
- Change content type to application/x-www-form-urlencoded 

### Steps to Reproduce:

1. Create a client instance with password grant type and valid credentials for base url https://api-test.neris.fsri.org/.
2. Attempt to create an incident.

