### PR TITLE
Add configuration parameter to controls whether performs model validations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ client = NerisApiClient()
 entity = client.get_entity("FD24027240")
 ```
 
+## Additional config parameters
+
+| Parameter | Description                                                 |
+| --------- | ----------------------------------------------------------- |
+| debug     | Controls whether the application outputs debug information. |
+| validate  | Controls whether the client performs model validations.     |
+
+
 ## Disclaimer
 The models in this package are generated using [`datamodel-code-generator`](https://github.com/koxudaxi/datamodel-code-generator) and are not guaranteed
 to contain all of the information present in the full specification. The generated models are used to validate request payloads prior to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neris_api_client"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
   { name="Ben Coleman", email="ben.coleman@ul.org" },
   { name="Tommy Messbauer", email="thomas.messbauer@ul.org" },

--- a/src/neris_api_client/client.py
+++ b/src/neris_api_client/client.py
@@ -161,7 +161,7 @@ class _NerisApiClient:
         self._update_auth()
         self._session.headers.update({"Authorization": f"Bearer {self.tokens.access_token}"})
 
-        if model:
+        if self.config.validate and model:
             if isinstance(data, str):
                 data = model.model_validate_json(data).model_dump(mode="json", by_alias=True)
             if isinstance(data, dict):

--- a/src/neris_api_client/config.py
+++ b/src/neris_api_client/config.py
@@ -16,11 +16,13 @@ class Config:
     client_id: str | None = None
     client_secret: str | None = None
     grant_type: GrantType | None = None
+    validate: bool | None = None
 
     def __post_init__(self):
         # env var handling
         self.base_url = self.base_url or os.getenv("NERIS_BASE_URL")
         self.debug = self.debug if self.debug is not None else os.getenv("NERIS_DEBUG") == "true"
+        self.validate = self.validate if self.validate is not None else os.getenv("NERIS_VALIDATE") == "true"
 
         match os.getenv("NERIS_GRANT_TYPE"):
             case GrantType.PASSWORD:


### PR DESCRIPTION
The models used in the NERIS API client to validate request payloads prior to API submission are not guaranteed to contain all of the information present in the full specification. This mistmatch at some point makes it difficult to test the API.

This PR introduces a new configuration paramenter to control whether model validation is enabled or disabled. This setting will provide more flexibility in configuring the application and allows to toggle the validation on or off via the client instance or an environment variable.

### Changes
- Added a configuration parameter to control whether model validation is enabled or disabled.
- Changed the condition for the execution of model validations, ensuring that the validation configuration parameter is taken into account.
- Documented in the README.md file the new configuration parameter.