### PR TITLE
Fix undefined variable error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neris_api_client"
-version = "1.3.0"
+version = "1.3.2"
 authors = [
   { name="Ben Coleman", email="ben.coleman@ul.org" },
   { name="Tommy Messbauer", email="thomas.messbauer@ul.org" },

--- a/src/neris_api_client/client.py
+++ b/src/neris_api_client/client.py
@@ -47,6 +47,7 @@ class _NerisApiClient:
             case GrantType.CLIENT_CREDENTIALS:
                 assert config.client_id is not None
                 assert config.client_secret is not None
+                self.client_creds = base64.b64encode(f"{config.client_id}:{config.client_secret}".encode("utf-8")).decode("utf-8")
             case GrantType.PASSWORD:
                 assert config.username is not None
                 assert config.password is not None
@@ -73,11 +74,9 @@ class _NerisApiClient:
                     )
 
                 case GrantType.CLIENT_CREDENTIALS:
-                    client_creds = base64.b64encode(f"{self.config.client_id}:{self.config.client_secret}".encode("utf-8")).decode("utf-8")
-
                     res = self._session.post(
                         token_url,
-                        headers={"Authorization": f"Basic {client_creds}", 'Content-Type': 'application/x-www-form-urlencoded'},
+                        headers={"Authorization": f"Basic {self.client_creds}", "Content-Type": "application/x-www-form-urlencoded"},
                         data={"grant_type": GrantType.CLIENT_CREDENTIALS},
                     )
 
@@ -97,11 +96,8 @@ class _NerisApiClient:
                 case GrantType.CLIENT_CREDENTIALS:
                     res = self._session.post(
                         token_url,
-                        headers={"Authorization": f"Basic {client_creds}", 'Content-Type': 'application/x-www-form-urlencoded'},
-                        data={
-                            "grant_type": "refresh_token",
-                            "refresh_token": self.tokens.refresh_token,
-                        },
+                        headers={"Authorization": f"Basic {self.client_creds}", "Content-Type": "application/x-www-form-urlencoded"},
+                        data={"grant_type": GrantType.CLIENT_CREDENTIALS},
                     )
 
         if not res:

--- a/src/neris_api_client/client.py
+++ b/src/neris_api_client/client.py
@@ -86,7 +86,7 @@ class _NerisApiClient:
                     res = self._session.post(
                         token_url,
                         # No basic auth needed for Cognito refresh tokens
-                        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                        headers={"Content-Type": "application/x-www-form-urlencoded"},
                         data={
                             "grant_type": "refresh_token",
                             "refresh_token": self.tokens.refresh_token,
@@ -96,8 +96,12 @@ class _NerisApiClient:
                 case GrantType.CLIENT_CREDENTIALS:
                     res = self._session.post(
                         token_url,
+                        # Basic auth required for NERIS refresh tokens
                         headers={"Authorization": f"Basic {self.client_creds}", "Content-Type": "application/x-www-form-urlencoded"},
-                        data={"grant_type": GrantType.CLIENT_CREDENTIALS},
+                        data={
+                            "grant_type": "refresh_token",
+                            "refresh_token": self.tokens.refresh_token,
+                        },
                     )
 
         if not res:


### PR DESCRIPTION
When the grant type is `client_credentials`, the refresh token branch was failing because `creds` was undefined.