### PR TITLE
API secret generation requires `title`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neris_api_client"
-version = "1.3.2"
+version = "1.3.3"
 authors = [
   { name="Ben Coleman", email="ben.coleman@ul.org" },
   { name="Tommy Messbauer", email="thomas.messbauer@ul.org" },

--- a/src/neris_api_client/client.py
+++ b/src/neris_api_client/client.py
@@ -316,8 +316,8 @@ class NerisApiClient(_NerisApiClient):
     def create_api_integration(self, neris_id: str, title: str) -> Dict[str, Any]:
         return self._call("post", f"/account/integration/{neris_id}", data={ "title": title })
 
-    def generate_api_secret(self, client_id: str) -> Dict[str, Any]:
-        return self._call("post", f"/account/credential/{client_id}")
+    def generate_api_secret(self, client_id: str, title: str) -> Dict[str, Any]:
+        return self._call("post", f"/account/credential/{client_id}", data={ "title": title })
 
     def list_integrations(self, neris_id: str) -> Dict[str, Any]:
         return self._call("get", f"/account/integration/{neris_id}/list")


### PR DESCRIPTION
Requests to `POST /account/credential/{client_id}` are failing because of missing request body param `title`.